### PR TITLE
The GitHub Action for creating releases was failing with a 403 Forbid…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
…den error. This was because the default GITHUB_TOKEN lacks the necessary permissions to create a release.

This commit adds the 'permissions: contents: write' block to the workflow job, granting it the required permissions to create GitHub releases.