### PR TITLE
Fix: Add paragraph tool to Editor.js configuration

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,9 +8,19 @@ document.addEventListener('DOMContentLoaded', () => {
             saveActiveNote();
         },
         tools: {
-            header: { class: 'Header', inlineToolbar: ['link'] },
-            list: { class: 'List', inlineToolbar: true }
-        },
+            header: {
+                class: 'Header',
+                inlineToolbar: ['link']
+            },
+            list: {
+                class: 'List',
+                inlineToolbar: true
+            },
+            paragraph: {
+                class: 'Paragraph',
+                inlineToolbar: true,
+            },
+        }
     });
 
     const noteList = document.getElementById('note-list');


### PR DESCRIPTION
The Editor.js instance was throwing an error because the 'paragraph' tool was not found. This happened because a custom 'tools' configuration was provided, which overrides the default set of tools.

This commit adds the 'paragraph' tool to the 'tools' object in the Editor.js configuration in `app.js`, resolving the error.