### PR TITLE
Implement sidebar reordering and pinned note display

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -294,9 +294,20 @@ a {
 	background: var(--primary-light);
 }
 
-/* Pinned Note Indicator */
-#note-list li.pinned {
-	display: none;
+.pin-note-unpin {
+	width: auto;
+	height: auto;
+	padding: 4px 12px;
+	font-size: 0.85rem;
+	border-radius: var(--radius-lg);
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
+	opacity: 1;
+}
+
+.pin-note-unpin:hover {
+	background: var(--danger-color);
+	color: var(--text-inverse);
 }
 
 /* Note Actions Container */
@@ -312,8 +323,49 @@ a {
 	opacity: 1;
 }
 
-#note-list li.pinned .note-actions {
-	opacity: 1;
+/* Pinned note display */
+#note-list li.pinned-display {
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
+	cursor: default;
+}
+
+#note-list li.pinned-display::before {
+	content: "";
+	position: absolute;
+	left: 0;
+	top: 50%;
+	transform: translateY(-50%) translateX(-8px);
+	width: 6px;
+	height: 28px;
+	background: var(--primary-color);
+	border-radius: 8px;
+}
+
+#note-list li.pinned-display:hover {
+	background: var(--bg-tertiary);
+}
+
+/* Drag and drop states */
+#note-list li[draggable="true"] {
+	cursor: grab;
+}
+
+#note-list li[draggable="true"]:active {
+	cursor: grabbing;
+}
+
+#note-list li.dragging {
+	opacity: 0.5;
+	cursor: grabbing;
+}
+
+#note-list li.drag-over-top {
+	box-shadow: inset 0 2px 0 var(--primary-color);
+}
+
+#note-list li.drag-over-bottom {
+	box-shadow: inset 0 -2px 0 var(--primary-color);
 }
 
 /* Simple Delete Button */


### PR DESCRIPTION
Implement drag-to-reorder for sidebar notes and display pinned notes as selected and non-interactive, revealing an unpin button on hover.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1ba429f-ee42-4aa3-a9b1-61ea75627bdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c1ba429f-ee42-4aa3-a9b1-61ea75627bdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

